### PR TITLE
Allow options on servers.all - as per the 'fog standard'

### DIFF
--- a/lib/fog/azure/models/compute/servers.rb
+++ b/lib/fog/azure/models/compute/servers.rb
@@ -28,7 +28,7 @@ module Fog
       class Servers < Fog::Collection
         model Fog::Compute::Azure::Server
 
-        def all()
+        def all(options = {})
           servers = []
           service.list_virtual_machines.each do |vm|
             hash = {}


### PR DESCRIPTION
Problem:

All other fog 'Servers' object allow you to pass an argument to `all`. The fact this one doesn't, means writing generic code for fog providers that relies on `.all(opts)` isn't possible. 

Solution:
fog's goal is to facilitate generic code for multiple compute resources, so I suggest this method takes the same number of arguments as the rest.
