### PR TITLE
Require azure/core manually

### DIFF
--- a/lib/fog/azure/compute.rb
+++ b/lib/fog/azure/compute.rb
@@ -72,7 +72,8 @@ module Fog
       class Real
         def initialize(options)
           begin
-            require "azure"
+            require 'azure'
+            require 'azure/core'
           rescue LoadError => e
             retry if require("rubygems")
             raise e.message


### PR DESCRIPTION
'azure' moved part of it to a gem called 'azure_core'. They released a
version that lists that gem as a dependency. When this version is
used with 'fog-azure', we get an error because 'azure/core' isn't loaded
(see https://github.com/Azure/azure-sdk-for-ruby/pull/383).

We can simply preload it in fog-azure and not let the error in the
dependency affect us. We could also force the dependency to be a version _before_ the split into 'azure' and 'azure_core'.

I think we'd need a new release after merging this change, as it stands right now fog-azure is broken (at least until https://github.com/Azure/azure-sdk-for-ruby/pull/383 is merged and a new release comes out)
