### PR TITLE
Fix database mocks & add travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: ruby
+rvm:
+- 2.0.0
+- 2.1.5
+- 2.2.0
+- 2.3.0
+script:
+- bundle install
+- bundle exec rake

--- a/lib/fog/azure/models/compute/database.rb
+++ b/lib/fog/azure/models/compute/database.rb
@@ -26,10 +26,11 @@ module Fog
     class Azure
       class Database < Fog::Model
         identity :name
-        attribute :feature_name
-        attribute :feature_value
-        attribute :location
-        attribute :administrator_login
+        attr_accessor :administrator_login
+        attr_accessor :location
+        attr_accessor :fully_qualified_domain_name
+        attr_accessor :version
+        attr_accessor :state
 
         def destroy
           requires :name

--- a/lib/fog/azure/requests/compute/create_database_server.rb
+++ b/lib/fog/azure/requests/compute/create_database_server.rb
@@ -30,11 +30,10 @@ module Fog
 
       class Mock
         def create_database_server(login, password, location)
-          db = ::Azure::SqlDatabaseManagement::SqlDatabase.new
+          db = ::Azure::SqlDatabaseManagement::SqlServer.new
           db.name = 'Mock Database'
           db.location = location
-          db.feature_name = 'Mock Database'
-          db.feature_value = 'value'
+          db.version = '12.0'
           db
         end
       end

--- a/lib/fog/azure/requests/compute/list_databases.rb
+++ b/lib/fog/azure/requests/compute/list_databases.rb
@@ -30,10 +30,9 @@ module Fog
 
       class Mock
         def list_databases
-          db = ::Azure::SqlDatabaseManagement::SqlDatabase.new
+          db = ::Azure::SqlDatabaseManagement::SqlServer.new
           db.name = 'Mock Database'
           db.location = 'US East'
-          db.feature_name = 'feature name'
           [db]
         end
       end

--- a/tests/models/compute/database_tests.rb
+++ b/tests/models/compute/database_tests.rb
@@ -33,10 +33,11 @@ Shindo.tests("Fog::Compute[:azure] | database model", ["azure", "compute"]) do
     tests("have attributes") do
       attributes = [
         :name,
-        :feature_name,
-        :feature_value,
+        :administrator_login,
         :location,
-        :administrator_login
+        :fully_qualified_domain_name,
+        :version,
+        :state
       ]
       tests("The database model should respond to") do
         attributes.each do |attribute|

--- a/tests/requests/compute/databases_tests.rb
+++ b/tests/requests/compute/databases_tests.rb
@@ -37,7 +37,7 @@ Shindo.tests("Fog::Compute[:azure] | database request", ["azure", "compute"]) do
      end
 
     test("should create a new database") do
-      databases.create('AdvancedAdminU', 'NotARegPW!', 'South Central US').kind_of? ::Azure::SqlDatabaseManagement::SqlDatabase
+      databases.create('AdvancedAdminU', 'NotARegPW!', 'South Central US').kind_of? ::Azure::SqlDatabaseManagement::SqlServer
     end
   end
 end


### PR DESCRIPTION
1. Fixing database mocks to use the correct class name as it was changed in latest azure gem. 
   Old Version: https://github.com/Azure/azure-sdk-for-ruby/blob/0.6.3-March2014/lib/azure/sql_database_management/sql_database.rb
   New Version: https://github.com/Azure/azure-sdk-for-ruby/blob/asm/lib/azure/sql_database_management/sql_server.rb
   REST API Reference Doc: https://msdn.microsoft.com/en-us/library/azure/dn505699.aspx
2. Plus added travis file for testing in travis-ci. 
3. Validation:

```
bundle exec rake
export FOG_MOCK=true && bundle exec shindont
[fog][WARNING] Setting default fog timeout to 2000 seconds

  Fog::Compute[:azure] | database model (azure, compute) ++++++++#  
  Fog::Compute[:azure] | image model (azure, compute) +++++  
  Fog::Compute[:azure] | server model (azure, compute) #  
  Fog::Compute[:azure] | storage account model (azure, compute) +++++++  
  Fog::Compute[:azure] | database request (azure, compute) ++++  
  Fog::Compute[:azure] | images request (azure, compute) +++  
  Fog::Compute[:azure] | servers request (azure, compute) +++  
  Fog::Compute[:azure] | storage accounts request (azure, compute) +++  
  2 pending, 33 succeeded in 0.186447 seconds

```

@jntullo & @jeffmendoza Please review and let me know if this PR requires any more changes. Thanks!
